### PR TITLE
Add `export` to types to fix TS1046 error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-const instance: {
+export const instance: {
     config: (options: {
         dateString?: string
         timestamp?: number


### PR DESCRIPTION
Bumped into a TS error:

```
node_modules/timemachine/index.d.ts:1:1 - error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

1 const instance: {
  ~~~~~
```

Adding an `export` fixes it!