### PR TITLE
inherit parse function from original Date

### DIFF
--- a/timemachine.js
+++ b/timemachine.js
@@ -87,6 +87,7 @@
         };
         Date.OriginalDate = OriginalDate;
         Date.UTC = OriginalDate.UTC;
+        Date.parse = OriginalDate.parse;
       },
 
       _getDifference: function() {


### PR DESCRIPTION
Allow to use Date.parse

```
Date.parse('2020-01-18T15:30:00-03:00') = 1579372200000
Date.parse('2020-01-18T50:40:00-03:00') = NaN
```

Alternative fix at project code
`if(!Date.parse) Date.parse = Date.prototype.constructor.parse`